### PR TITLE
feat: 記事カードのborderとストライプを削除してシンプルなデザインに

### DIFF
--- a/src/components/common/MetaInfo.tsx
+++ b/src/components/common/MetaInfo.tsx
@@ -17,8 +17,7 @@ export const MetaInfo = ({ createdAt, author, variant = 'card' }: MetaInfoProps)
       gap: '16px',
       ...(variant === 'card' && {
         marginTop: '16px',
-        paddingTop: '16px',
-        borderTop: '1px solid #e5e7eb'
+        paddingTop: '16px'
       })
     })}>
       <div className={css({

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,7 +31,8 @@ const Index = () => {
             <div className={css({
               display: 'flex',
               flexDirection: 'column',
-              gap: '32px'
+              gap: '32px',
+              paddingTop: '12px'
             })}>
               {posts.map((post) => (
                 <article 
@@ -50,7 +51,8 @@ const Index = () => {
                 >
                   <div className={css({ 
                     padding: 'card',
-                    paddingBottom: '12px'
+                    paddingBottom: '12px',
+                    paddingX: '12px'
                   })}>
                     <MetaInfo
                       createdAt={post.createdAt}
@@ -58,15 +60,6 @@ const Index = () => {
                       variant="card"
                     />
                   </div>
-                  
-                  <div className={css({
-                    borderTop: '1px solid #e5e7eb'
-                  })} />
-                  
-                  <div className={css({
-                    height: '4px',
-                    background: 'gradients.cardStripe'
-                  })} />
                   
                   <div className={css({ padding: 'card' })}>
                     <Link 


### PR DESCRIPTION
## 概要

- MetaInfoコンポーネントのborderTop削除
- 記事カードのストライプ（gradients.cardStripe）を削除
- グレーのborder線（borderTop: '1px solid #e5e7eb'）を削除
- 日付・著者名に左右12pxのpaddingを追加
- 記事一覧上部に12pxのpaddingを追加してホバーアニメーション時の重なりを防止

## 変更内容

- スタイル、不要エレメントの削除

## 備考
